### PR TITLE
docs: add project overview and hardware notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
-# mars rover
-A 3D-printable rover that utilizes a raspberry pi 5 and some python to run mission simulations.
+# Mars Rover
+
+## Features
+- 3D‑printable chassis designed for rapid prototyping.
+- Raspberry Pi 5 controller running Python‑based mission software.
+- Modular sensor bays and expandable motor drivers.
+
+## Quick Start
+```bash
+git clone https://github.com/your-org/mars-rover.git
+cd mars-rover
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+python rover.py --config config/rover.yaml
+```
+Adjust parameters inside [`config/rover.yaml`](config/rover.yaml) to match your hardware setup.
+
+## Hardware Reference
+See [docs/](docs/) for wiring diagrams and additional hardware notes.
+Mechanical models suitable for fabrication are located in the [cad/](cad/) directory.
+

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,11 @@
+# Hardware Notes
+
+This directory houses documentation for assembling and maintaining the **Mars Rover** hardware.
+
+## Wiring Diagrams
+Detailed wiring diagrams for motors, sensors, and power distribution should be placed alongside these notes.
+
+## CAD Assets
+Mechanical components are modelled and stored in the [cad/](../cad/) directory.
+Import these files into your favourite CAD suite for modification or 3D printing.
+


### PR DESCRIPTION
## Summary
- Outline rover features, quick-start commands, and hardware references in root README.
- Add hardware notes and CAD directory links under `docs/`.
- Include placeholder `cad/` directory for future models.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab683cad88832eaf051a209d26ab40