### PR TITLE
feat: implement deck-rover radio link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,14 @@
+"""Common utilities shared across subsystems."""
+
+from .config import Config
+from .schema import TelemetryPacket, Command
+from .utils import current_time_iso, clamp, ensure
+
+__all__ = [
+    "Config",
+    "TelemetryPacket",
+    "Command",
+    "current_time_iso",
+    "clamp",
+    "ensure",
+]

--- a/common/config.py
+++ b/common/config.py
@@ -1,0 +1,20 @@
+"""Configuration helpers."""
+
+from dataclasses import dataclass
+import os
+
+
+@dataclass
+class Config:
+    """Simple configuration object loaded from environment variables."""
+
+    rover_name: str = "MarsRover"
+    deck_port: int = 8000
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        """Create a :class:`Config` from environment variables."""
+        return cls(
+            rover_name=os.getenv("ROVER_NAME", cls.rover_name),
+            deck_port=int(os.getenv("DECK_PORT", cls.deck_port)),
+        )

--- a/common/schema.py
+++ b/common/schema.py
@@ -1,0 +1,21 @@
+"""Shared data schemas."""
+
+from dataclasses import dataclass
+from typing import Dict, Any
+
+
+@dataclass
+class TelemetryPacket:
+    """Telemetry information sent from the rover."""
+
+    timestamp: str
+    temperature: float
+    battery_level: float
+
+
+@dataclass
+class Command:
+    """Command sent to the rover or deck."""
+
+    command_type: str
+    payload: Dict[str, Any]

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,0 +1,20 @@
+"""Utility functions."""
+
+from datetime import datetime
+from typing import Any
+
+
+def current_time_iso() -> str:
+    """Return the current UTC time in ISO-8601 format."""
+    return datetime.utcnow().isoformat() + "Z"
+
+
+def clamp(value: float, minimum: float, maximum: float) -> float:
+    """Clamp ``value`` between ``minimum`` and ``maximum``."""
+    return max(minimum, min(value, maximum))
+
+
+def ensure(condition: bool, message: str) -> None:
+    """Raise a :class:`ValueError` if ``condition`` is False."""
+    if not condition:
+        raise ValueError(message)

--- a/common/utils.py
+++ b/common/utils.py
@@ -1,12 +1,12 @@
 """Utility functions."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 
 def current_time_iso() -> str:
     """Return the current UTC time in ISO-8601 format."""
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat()
 
 
 def clamp(value: float, minimum: float, maximum: float) -> float:

--- a/deck/__init__.py
+++ b/deck/__init__.py
@@ -1,0 +1,17 @@
+"""Deck subsystem package."""
+
+from .main import main
+from .ui import DeckUI
+from .alarms import AlarmManager
+from .radio import DeckRadio
+from .sims import Simulation
+from .telemetry import TelemetryCollector
+
+__all__ = [
+    "main",
+    "DeckUI",
+    "AlarmManager",
+    "DeckRadio",
+    "Simulation",
+    "TelemetryCollector",
+]

--- a/deck/alarms/__init__.py
+++ b/deck/alarms/__init__.py
@@ -1,0 +1,5 @@
+"""Alarm package for the deck subsystem."""
+
+from .alarms import AlarmManager
+
+__all__ = ["AlarmManager"]

--- a/deck/alarms/alarms.py
+++ b/deck/alarms/alarms.py
@@ -1,0 +1,24 @@
+"""Alarm management for the deck subsystem."""
+
+from typing import List
+
+
+class AlarmManager:
+    """Manage active alarms for the deck system."""
+
+    def __init__(self) -> None:
+        self.active_alarms: List[str] = []
+
+    def raise_alarm(self, alarm: str) -> None:
+        """Add an alarm to the active list."""
+        if alarm not in self.active_alarms:
+            self.active_alarms.append(alarm)
+
+    def clear_alarm(self, alarm: str) -> None:
+        """Remove an alarm from the active list."""
+        if alarm in self.active_alarms:
+            self.active_alarms.remove(alarm)
+
+    def is_active(self, alarm: str) -> bool:
+        """Check if an alarm is currently active."""
+        return alarm in self.active_alarms

--- a/deck/main.py
+++ b/deck/main.py
@@ -1,0 +1,29 @@
+"""Main entry point for the deck subsystem."""
+
+from deck.ui import DeckUI
+from deck.alarms import AlarmManager
+from deck.telemetry import TelemetryCollector
+from deck.radio import DeckRadio
+from deck.sims import Simulation
+
+
+def main() -> None:
+    """Demonstrate basic deck functionality."""
+    ui = DeckUI()
+    alarms = AlarmManager()
+    telemetry = TelemetryCollector()
+    radio = DeckRadio()
+    sim = Simulation()
+
+    sim.start()
+    packet = telemetry.collect()
+    ui.display_message(f"Telemetry collected: {packet}")
+    radio.send("Telemetry packet sent")
+    if packet.battery_level < 20.0:
+        alarms.raise_alarm("Low battery")
+        ui.display_message("Alarm: Low battery")
+    sim.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/deck/radio/__init__.py
+++ b/deck/radio/__init__.py
@@ -1,0 +1,5 @@
+"""Radio package for the deck subsystem."""
+
+from .radio import DeckRadio
+
+__all__ = ["DeckRadio"]

--- a/deck/radio/radio.py
+++ b/deck/radio/radio.py
@@ -1,0 +1,35 @@
+"""Radio communications for the deck subsystem."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from rover.radio import RoverRadio
+
+
+class DeckRadio:
+    """In-memory radio link for the deck.
+
+    Messages sent through :meth:`send` are delivered to the connected
+    :class:`~rover.radio.RoverRadio` instance's inbox. Incoming messages from
+    the rover are stored in :attr:`inbox` and retrieved via :meth:`receive`.
+    """
+
+    def __init__(self) -> None:
+        self.inbox: List[Any] = []
+        self.peer: Optional[RoverRadio] = None
+
+    def connect(self, rover_radio: RoverRadio) -> None:
+        """Connect this radio to the rover's radio."""
+        self.peer = rover_radio
+        rover_radio.peer = self
+
+    def send(self, message: Any) -> None:
+        """Transmit ``message`` to the rover if connected."""
+        if self.peer is not None:
+            self.peer.inbox.append(message)
+
+    def receive(self) -> Optional[Any]:
+        """Retrieve the oldest message from the inbox, if any."""
+        return self.inbox.pop(0) if self.inbox else None

--- a/deck/sims/__init__.py
+++ b/deck/sims/__init__.py
@@ -1,0 +1,5 @@
+"""Simulation package for the deck subsystem."""
+
+from .sims import Simulation
+
+__all__ = ["Simulation"]

--- a/deck/sims/sims.py
+++ b/deck/sims/sims.py
@@ -1,0 +1,16 @@
+"""Simulation tools for the deck subsystem."""
+
+
+class Simulation:
+    """Very small simulation harness."""
+
+    def __init__(self) -> None:
+        self.running = False
+
+    def start(self) -> None:
+        """Start the simulation."""
+        self.running = True
+
+    def stop(self) -> None:
+        """Stop the simulation."""
+        self.running = False

--- a/deck/telemetry/__init__.py
+++ b/deck/telemetry/__init__.py
@@ -1,0 +1,5 @@
+"""Telemetry package for the deck subsystem."""
+
+from .telemetry import TelemetryCollector
+
+__all__ = ["TelemetryCollector"]

--- a/deck/telemetry/telemetry.py
+++ b/deck/telemetry/telemetry.py
@@ -1,0 +1,18 @@
+"""Telemetry collection for the deck subsystem."""
+
+import random
+
+from common.schema import TelemetryPacket
+from common.utils import current_time_iso
+
+
+class TelemetryCollector:
+    """Generate random telemetry samples."""
+
+    def collect(self) -> TelemetryPacket:
+        """Collect a single telemetry packet."""
+        return TelemetryPacket(
+            timestamp=current_time_iso(),
+            temperature=random.uniform(-80.0, 0.0),
+            battery_level=random.uniform(0.0, 100.0),
+        )

--- a/deck/ui/__init__.py
+++ b/deck/ui/__init__.py
@@ -1,0 +1,5 @@
+"""UI package for the deck subsystem."""
+
+from .ui import DeckUI
+
+__all__ = ["DeckUI"]

--- a/deck/ui/ui.py
+++ b/deck/ui/ui.py
@@ -1,0 +1,15 @@
+"""User interface for the deck subsystem."""
+
+from typing import List
+
+
+class DeckUI:
+    """Simple UI component that records and displays messages."""
+
+    def __init__(self) -> None:
+        self.log: List[str] = []
+
+    def display_message(self, message: str) -> None:
+        """Display a message to the operator."""
+        self.log.append(message)
+        print(f"[UI] {message}")

--- a/rover/__init__.py
+++ b/rover/__init__.py
@@ -1,0 +1,17 @@
+"""Rover subsystem package."""
+
+from .main import main
+from .drive import DriveSystem
+from .claw import ClawController
+from .sensors import SensorSuite
+from .radio import RoverRadio
+from .faults import FaultDetector
+
+__all__ = [
+    "main",
+    "DriveSystem",
+    "ClawController",
+    "SensorSuite",
+    "RoverRadio",
+    "FaultDetector",
+]

--- a/rover/claw/__init__.py
+++ b/rover/claw/__init__.py
@@ -1,0 +1,5 @@
+"""Claw package for the rover subsystem."""
+
+from .claw import ClawController
+
+__all__ = ["ClawController"]

--- a/rover/claw/claw.py
+++ b/rover/claw/claw.py
@@ -1,0 +1,20 @@
+"""Claw control for the rover subsystem."""
+
+
+class ClawController:
+    """Operate a simple open/close claw."""
+
+    def __init__(self) -> None:
+        self.open = True
+
+    def open_claw(self) -> None:
+        """Open the claw."""
+        self.open = True
+
+    def close_claw(self) -> None:
+        """Close the claw."""
+        self.open = False
+
+    def is_open(self) -> bool:
+        """Return whether the claw is open."""
+        return self.open

--- a/rover/drive/__init__.py
+++ b/rover/drive/__init__.py
@@ -1,0 +1,5 @@
+"""Drive package for the rover subsystem."""
+
+from .drive import DriveSystem
+
+__all__ = ["DriveSystem"]

--- a/rover/drive/drive.py
+++ b/rover/drive/drive.py
@@ -1,0 +1,20 @@
+"""Drive system for the rover."""
+
+
+class DriveSystem:
+    """Simple rover drive control."""
+
+    def __init__(self) -> None:
+        self.speed = 0.0
+
+    def set_speed(self, speed: float) -> None:
+        """Set the rover's speed."""
+        self.speed = speed
+
+    def stop(self) -> None:
+        """Stop the rover."""
+        self.speed = 0.0
+
+    def get_speed(self) -> float:
+        """Return the current speed."""
+        return self.speed

--- a/rover/faults/__init__.py
+++ b/rover/faults/__init__.py
@@ -1,0 +1,5 @@
+"""Fault detection package for the rover."""
+
+from .faults import FaultDetector
+
+__all__ = ["FaultDetector"]

--- a/rover/faults/faults.py
+++ b/rover/faults/faults.py
@@ -1,0 +1,18 @@
+"""Fault detection for the rover."""
+
+from typing import List
+
+
+class FaultDetector:
+    """Track reported faults in the rover."""
+
+    def __init__(self) -> None:
+        self.faults: List[str] = []
+
+    def report_fault(self, fault: str) -> None:
+        """Record a fault condition."""
+        self.faults.append(fault)
+
+    def has_faults(self) -> bool:
+        """Return True if any faults have been reported."""
+        return bool(self.faults)

--- a/rover/main.py
+++ b/rover/main.py
@@ -1,0 +1,34 @@
+"""Main entry point for the rover subsystem."""
+
+from rover.drive import DriveSystem
+from rover.claw import ClawController
+from rover.sensors import SensorSuite
+from rover.radio import RoverRadio
+from rover.faults import FaultDetector
+
+
+def main() -> None:
+    """Demonstrate basic rover functionality."""
+    drive = DriveSystem()
+    claw = ClawController()
+    sensors = SensorSuite()
+    radio = RoverRadio()
+    faults = FaultDetector()
+
+    drive.set_speed(1.0)
+    radio.transmit(f"Speed set to {drive.get_speed()}")
+
+    temp = sensors.read_temperature()
+    radio.transmit(f"Temperature reading: {temp:.2f}C")
+    if temp < -50.0:
+        faults.report_fault("Extreme cold")
+
+    claw.close_claw()
+    radio.transmit(f"Claw open? {claw.is_open()}")
+
+    drive.stop()
+    radio.transmit("Rover stopped")
+
+
+if __name__ == "__main__":
+    main()

--- a/rover/radio/__init__.py
+++ b/rover/radio/__init__.py
@@ -1,0 +1,5 @@
+"""Radio package for the rover subsystem."""
+
+from .radio import RoverRadio
+
+__all__ = ["RoverRadio"]

--- a/rover/radio/radio.py
+++ b/rover/radio/radio.py
@@ -1,0 +1,35 @@
+"""Radio communications for the rover."""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover - imported for type checking only
+    from deck.radio import DeckRadio
+
+
+class RoverRadio:
+    """Simulated rover radio interface."""
+
+    def __init__(self) -> None:
+        self.inbox: List[Any] = []
+        self.peer: Optional[DeckRadio] = None
+
+    def connect(self, deck_radio: DeckRadio) -> None:
+        """Connect this radio to the deck's radio."""
+        self.peer = deck_radio
+        deck_radio.peer = self
+
+    def transmit(self, message: Any) -> None:
+        """Transmit ``message`` to the deck and print it."""
+        if self.peer is not None:
+            self.peer.inbox.append(message)
+        print(f"[RoverRadio] {message}")
+
+    def receive(self) -> Optional[Any]:
+        """Retrieve the oldest message from the inbox, if any."""
+        return self.inbox.pop(0) if self.inbox else None
+
+    def last_message(self) -> Any | None:
+        """Return the most recent received message, if any."""
+        return self.inbox[-1] if self.inbox else None

--- a/rover/sensors/__init__.py
+++ b/rover/sensors/__init__.py
@@ -1,0 +1,5 @@
+"""Sensors package for the rover subsystem."""
+
+from .sensors import SensorSuite
+
+__all__ = ["SensorSuite"]

--- a/rover/sensors/sensors.py
+++ b/rover/sensors/sensors.py
@@ -1,0 +1,11 @@
+"""Sensor suite for the rover."""
+
+import random
+
+
+class SensorSuite:
+    """Provide access to rover sensors."""
+
+    def read_temperature(self) -> float:
+        """Return a simulated temperature reading."""
+        return random.uniform(-80.0, 0.0)

--- a/tests/test_system.py
+++ b/tests/test_system.py
@@ -1,0 +1,80 @@
+import math
+import sys
+from pathlib import Path
+
+# Ensure project root is on sys.path when tests are executed from the tests directory
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from common.schema import TelemetryPacket
+from deck.alarms.alarms import AlarmManager
+from deck.radio.radio import DeckRadio
+from deck.telemetry.telemetry import TelemetryCollector
+from deck.ui.ui import DeckUI
+from rover.claw.claw import ClawController
+from rover.drive.drive import DriveSystem
+from rover.faults.faults import FaultDetector
+from rover.radio.radio import RoverRadio
+from rover.sensors.sensors import SensorSuite
+
+
+def test_alarm_manager():
+    mgr = AlarmManager()
+    mgr.raise_alarm("low_battery")
+    assert mgr.is_active("low_battery")
+    mgr.clear_alarm("low_battery")
+    assert not mgr.is_active("low_battery")
+
+
+def test_drive_and_claw():
+    drive = DriveSystem()
+    drive.set_speed(2.5)
+    assert math.isclose(drive.get_speed(), 2.5)
+    drive.stop()
+    assert drive.get_speed() == 0.0
+
+    claw = ClawController()
+    claw.close_claw()
+    assert not claw.is_open()
+    claw.open_claw()
+    assert claw.is_open()
+
+
+def test_fault_detector():
+    faults = FaultDetector()
+    faults.report_fault("motor")
+    assert faults.has_faults()
+
+
+def test_sensor_and_telemetry_range():
+    sensors = SensorSuite()
+    temp = sensors.read_temperature()
+    assert -80.0 <= temp <= 0.0
+
+    collector = TelemetryCollector()
+    packet = collector.collect()
+    assert isinstance(packet, TelemetryPacket)
+    assert -80.0 <= packet.temperature <= 0.0
+    assert 0.0 <= packet.battery_level <= 100.0
+
+
+def test_ui_and_radio_link():
+    deck_radio = DeckRadio()
+    rover_radio = RoverRadio()
+    deck_radio.connect(rover_radio)
+
+    # Rover sends telemetry
+    packet = TelemetryCollector().collect()
+    rover_radio.transmit(packet)
+
+    received = deck_radio.receive()
+    assert isinstance(received, TelemetryPacket)
+
+    ui = DeckUI()
+    ui.display_message("hello")
+    assert ui.log == ["hello"]
+
+    # Deck sends command to rover
+    deck_radio.send("move")
+    assert rover_radio.receive() == "move"


### PR DESCRIPTION
## Summary
- add in-memory radio connection between deck and rover
- cover core subsystems with unit tests

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab683a8440832eae21315c80225b09